### PR TITLE
make OpenSoT compatible with ROS 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Enrico Mingo Hoffman, Alessio Rocchi
 # CopyPolicy: Released under the terms of the GNU GPL v2.0.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 include(ExternalProject)
 project(open_sot VERSION 4.0.0)
 
@@ -26,7 +26,7 @@ add_subdirectory(doc)
 find_package(Boost COMPONENTS system REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(orocos_kdl REQUIRED)
-find_package(urdf REQUIRED)
+find_package(urdfdom REQUIRED)
 find_package(kdl_parser REQUIRED)
 find_package(moveit_core QUIET)
 
@@ -36,7 +36,7 @@ find_package(PCL 1.7 QUIET COMPONENTS   common
                                         #search
                                         #io)
                                                                                 
-find_package(eigen_conversions REQUIRED)
+find_package(tf2_eigen_kdl REQUIRED)
 find_package(xbot2_interface REQUIRED)
 find_package(PkgConfig REQUIRED)
 find_package(matlogger2 REQUIRED)
@@ -66,7 +66,7 @@ endif()
 
 # add include directories
 INCLUDE_DIRECTORIES(include ${EIGEN3_INCLUDE_DIR}
-    ${PCL_INCLUDE_DIRS} ${XBotInterface_INCLUDE_DIRS} ${eigen_conversions_INCLUDE_DIRS}
+    ${PCL_INCLUDE_DIRS} ${XBotInterface_INCLUDE_DIRS} ${tf2_eigen_kdl_INCLUDE_DIRS}
     )
 
 ADD_DEFINITIONS(${PCL_DEFINITIONS})
@@ -153,7 +153,7 @@ set(OPENSOT_SOLVERS_SOURCES src/solvers/BackEnd.cpp
     src/solvers/eHQP.cpp
     src/solvers/l1HQP.cpp)
 
-option(OPENSOT_SOTH_FRONT_END "Add to compilation soth and HCOD front-end" OFF)
+option(OPENSOT_SOTH_FRONT_END "Add to compilation soth and HCOD front-end" ON)
 if(${OPENSOT_SOTH_FRONT_END})
     message("Internal soth will be used!")
     add_subdirectory(external/soth-ext/)
@@ -189,7 +189,7 @@ ADD_LIBRARY(OpenSoT SHARED
     ${OPENSOT_VARIABLES_SOURCES}
     ${sot_INCLUDES})
 
-set(PRIVATE_TLL ${PRIVATE_TLL} ${eigen_conversions_LIBRARIES})
+set(PRIVATE_TLL ${PRIVATE_TLL} tf2_eigen_kdl::tf2_eigen_kdl)
 if(${OPENSOT_COMPILE_COLLISION})
     target_link_libraries(OpenSoT PUBLIC xbot2_interface::collision)
 endif()
@@ -312,7 +312,7 @@ install(DIRECTORY include/
     DESTINATION include
     FILES_MATCHING PATTERN "*.h")
 
-include(AddUninstallTarget)
+#include(AddUninstallTarget)
 include(MacroInstallLib)
 
 library_install(OpenSoT

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -35,7 +35,7 @@ if(${pybind11_FOUND})
 
     install(TARGETS pyopensot
         COMPONENT python
-        LIBRARY DESTINATION "~/.local/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages"
+        LIBRARY DESTINATION "/usr/local/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/dist-packages"
         ARCHIVE DESTINATION "lib"
         RUNTIME DESTINATION "bin")
 

--- a/cmake/Modules/GenerateDeb.cmake
+++ b/cmake/Modules/GenerateDeb.cmake
@@ -1,14 +1,14 @@
 message("**** Creating target release_deb to generate .deb for ${PROJECT_NAME}, to use it type: make release_deb ****")
 include (InstallRequiredSystemLibraries)
 
-set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/xbot" CACHE PATH "Deb package install prefix")
+set(CPACK_PACKAGING_INSTALL_PREFIX "/usr/local" CACHE PATH "Deb package install prefix")
 set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
 
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
 set(CPACK_PACKAGE_ARCHITECTURE "amd64")
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "xbotinterface, matlogger2, modelinterfacerbdl")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "xbot2_interface, matlogger2")
 
 #set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS ON)

--- a/examples/cpp/coman_ik.cpp
+++ b/examples/cpp/coman_ik.cpp
@@ -71,27 +71,27 @@ void publishJointStates(const Eigen::VectorXd& q, const Eigen::Affine3d& start, 
     static auto joint_state_pub = n.advertise<sensor_msgs::JointState>("joint_states", 1000);
     joint_state_pub.publish(joint_msg);
 
-    static tf::TransformBroadcaster br;
-    tf::Transform transform_start, transform_goal;
-    tf::Pose pose_start, pose_goal;
-    tf::poseEigenToTF(start, pose_start);
+    static tf2::TransformBroadcaster br;
+    tf2::Transform transform_start, transform_goal;
+    tf2::Pose pose_start, pose_goal;
+    tf2::poseEigenToTF(start, pose_start);
     transform_start.setOrigin(pose_start.getOrigin());
     transform_start.setRotation(pose_start.getRotation());
-    tf::poseEigenToTF(goal, pose_goal);
+    tf2::poseEigenToTF(goal, pose_goal);
     transform_goal.setOrigin(pose_goal.getOrigin());
     transform_goal.setRotation(pose_goal.getRotation());
 
     Eigen::Affine3d floating_base;
     model->getFloatingBasePose(floating_base);
-    tf::Transform transform_floating_base;
-    tf::Pose pose_floating_base;
-    tf::poseEigenToTF(floating_base, pose_floating_base);
+    tf2::Transform transform_floating_base;
+    tf2::Pose pose_floating_base;
+    tf2::poseEigenToTF(floating_base, pose_floating_base);
     transform_floating_base.setOrigin(pose_floating_base.getOrigin());
     transform_floating_base.setRotation(pose_floating_base.getRotation());
 
-    br.sendTransform(tf::StampedTransform(transform_floating_base, joint_msg.header.stamp, "world", "base_link"));
-    br.sendTransform(tf::StampedTransform(transform_start, joint_msg.header.stamp, "world", "start"));
-    br.sendTransform(tf::StampedTransform(transform_goal, joint_msg.header.stamp, "world", "goal"));
+    br.sendTransform(tf2::StampedTransform(transform_floating_base, joint_msg.header.stamp, "world", "base_link"));
+    br.sendTransform(tf2::StampedTransform(transform_start, joint_msg.header.stamp, "world", "start"));
+    br.sendTransform(tf2::StampedTransform(transform_goal, joint_msg.header.stamp, "world", "goal"));
 }
 
 /**

--- a/examples/cpp/coman_ik_hcod.cpp
+++ b/examples/cpp/coman_ik_hcod.cpp
@@ -69,27 +69,27 @@ void publishJointStates(const Eigen::VectorXd& q, const Eigen::Affine3d& start, 
     static auto joint_state_pub = n.advertise<sensor_msgs::JointState>("joint_states", 1000);
     joint_state_pub.publish(joint_msg);
 
-    static tf::TransformBroadcaster br;
-    tf::Transform transform_start, transform_goal;
-    tf::Pose pose_start, pose_goal;
-    tf::poseEigenToTF(start, pose_start);
+    static tf2::TransformBroadcaster br;
+    tf2::Transform transform_start, transform_goal;
+    tf2::Pose pose_start, pose_goal;
+    tf2::poseEigenToTF(start, pose_start);
     transform_start.setOrigin(pose_start.getOrigin());
     transform_start.setRotation(pose_start.getRotation());
-    tf::poseEigenToTF(goal, pose_goal);
+    tf2::poseEigenToTF(goal, pose_goal);
     transform_goal.setOrigin(pose_goal.getOrigin());
     transform_goal.setRotation(pose_goal.getRotation());
 
     Eigen::Affine3d floating_base;
     model->getFloatingBasePose(floating_base);
-    tf::Transform transform_floating_base;
-    tf::Pose pose_floating_base;
-    tf::poseEigenToTF(floating_base, pose_floating_base);
+    tf2::Transform transform_floating_base;
+    tf2::Pose pose_floating_base;
+    tf2::poseEigenToTF(floating_base, pose_floating_base);
     transform_floating_base.setOrigin(pose_floating_base.getOrigin());
     transform_floating_base.setRotation(pose_floating_base.getRotation());
 
-    br.sendTransform(tf::StampedTransform(transform_floating_base, joint_msg.header.stamp, "world", "base_link"));
-    br.sendTransform(tf::StampedTransform(transform_start, joint_msg.header.stamp, "world", "start"));
-    br.sendTransform(tf::StampedTransform(transform_goal, joint_msg.header.stamp, "world", "goal"));
+    br.sendTransform(tf2::StampedTransform(transform_floating_base, joint_msg.header.stamp, "world", "base_link"));
+    br.sendTransform(tf2::StampedTransform(transform_start, joint_msg.header.stamp, "world", "start"));
+    br.sendTransform(tf2::StampedTransform(transform_goal, joint_msg.header.stamp, "world", "goal"));
 }
 
 

--- a/examples/cpp/panda_ik.cpp
+++ b/examples/cpp/panda_ik.cpp
@@ -85,18 +85,18 @@ void publishJointStates(const Eigen::VectorXd& q, const Eigen::Affine3d& start, 
     static auto joint_state_pub = n.advertise<sensor_msgs::JointState>("joint_states", 1000);
     joint_state_pub.publish(msg);
 
-    static tf::TransformBroadcaster br;
-    tf::Transform transform_start, transform_goal;
-    tf::Pose pose_start, pose_goal;
-    tf::poseEigenToTF(start, pose_start);
+    static tf2::TransformBroadcaster br;
+    tf2::Transform transform_start, transform_goal;
+    tf2::Pose pose_start, pose_goal;
+    tf2::poseEigenToTF(start, pose_start);
     transform_start.setOrigin(pose_start.getOrigin());
     transform_start.setRotation(pose_start.getRotation());
-    tf::poseEigenToTF(goal, pose_goal);
+    tf2::poseEigenToTF(goal, pose_goal);
     transform_goal.setOrigin(pose_goal.getOrigin());
     transform_goal.setRotation(pose_goal.getRotation());
 
-    br.sendTransform(tf::StampedTransform(transform_start, msg.header.stamp, "base_link", "start"));
-    br.sendTransform(tf::StampedTransform(transform_goal, msg.header.stamp, "base_link", "goal"));
+    br.sendTransform(tf2::StampedTransform(transform_start, msg.header.stamp, "base_link", "start"));
+    br.sendTransform(tf2::StampedTransform(transform_goal, msg.header.stamp, "base_link", "goal"));
 }
 
 /**

--- a/examples/cpp/panda_ik_hcod.cpp
+++ b/examples/cpp/panda_ik_hcod.cpp
@@ -81,18 +81,18 @@ void publishJointStates(const Eigen::VectorXd& q, const Eigen::Affine3d& start, 
     static auto joint_state_pub = n.advertise<sensor_msgs::JointState>("joint_states", 1000);
     joint_state_pub.publish(msg);
 
-    static tf::TransformBroadcaster br;
-    tf::Transform transform_start, transform_goal;
-    tf::Pose pose_start, pose_goal;
-    tf::poseEigenToTF(start, pose_start);
+    static tf2::TransformBroadcaster br;
+    tf2::Transform transform_start, transform_goal;
+    tf2::Pose pose_start, pose_goal;
+    tf2::poseEigenToTF(start, pose_start);
     transform_start.setOrigin(pose_start.getOrigin());
     transform_start.setRotation(pose_start.getRotation());
-    tf::poseEigenToTF(goal, pose_goal);
+    tf2::poseEigenToTF(goal, pose_goal);
     transform_goal.setOrigin(pose_goal.getOrigin());
     transform_goal.setRotation(pose_goal.getRotation());
 
-    br.sendTransform(tf::StampedTransform(transform_start, msg.header.stamp, "base_link", "start"));
-    br.sendTransform(tf::StampedTransform(transform_goal, msg.header.stamp, "base_link", "goal"));
+    br.sendTransform(tf2::StampedTransform(transform_start, msg.header.stamp, "base_link", "start"));
+    br.sendTransform(tf2::StampedTransform(transform_goal, msg.header.stamp, "base_link", "goal"));
 }
 
 /**

--- a/examples/cpp/static_walk.cpp
+++ b/examples/cpp/static_walk.cpp
@@ -16,7 +16,7 @@
 #include "qp_estimation.h"
 #include <sensor_msgs/JointState.h>
 #include "../../tests/common.h"
-#include <eigen_conversions/eigen_kdl.h>
+#include <tf2_eigen_kdl/tf2_eigen_kdl.hpp>
 
 
 bool IS_ROSCORE_RUNNING;
@@ -229,7 +229,7 @@ namespace{
               **/
             if(IS_ROSCORE_RUNNING){
                 _n.reset(new ros::NodeHandle());
-                world_broadcaster.reset(new tf::TransformBroadcaster());
+                world_broadcaster.reset(new tf2::TransformBroadcaster());
             }
         }
 
@@ -357,10 +357,10 @@ namespace{
                 Eigen::Affine3d world_T_bl;
                 _model_ptr->getPose("Waist",world_T_bl);
 
-                tf::Transform anchor_T_world;
-                tf::transformEigenToTF(world_T_bl, anchor_T_world);
+                tf2::Transform anchor_T_world;
+                tf2::transformEigenToTF(world_T_bl, anchor_T_world);
 
-                world_broadcaster->sendTransform(tf::StampedTransform(
+                world_broadcaster->sendTransform(tf2::StampedTransform(
                     anchor_T_world.inverse(), joint_msg.header.stamp,
                     "Waist", "world"));
 
@@ -376,7 +376,7 @@ namespace{
         std::shared_ptr<trajectory_utils::trajectory_publisher> com_trj_pub, l_sole_trj_pub, r_sole_trj_pub, r_wrist_trj_pub;
 
         ros::Publisher joint_state_pub;
-        std::shared_ptr<tf::TransformBroadcaster> world_broadcaster;
+        std::shared_ptr<tf2::TransformBroadcaster> world_broadcaster;
 
         rviz_visual_tools::RvizVisualToolsPtr visual_tools;
 
@@ -435,9 +435,9 @@ namespace{
               * @brief Initialize trajectories, publiahers and walking stack
               **/
             KDL::Frame com_init_kdl, l_foot_init_kdl, r_foot_init_kdl;
-            tf::transformEigenToKDL(com_init, com_init_kdl);
-            tf::transformEigenToKDL(l_foot_init, l_foot_init_kdl);
-            tf::transformEigenToKDL(r_foot_init, r_foot_init_kdl);
+            tf2::transformEigenToKDL(com_init, com_init_kdl);
+            tf2::transformEigenToKDL(l_foot_init, l_foot_init_kdl);
+            tf2::transformEigenToKDL(r_foot_init, r_foot_init_kdl);
             this->initTrj(com_init_kdl, l_foot_init_kdl, r_foot_init_kdl);
             this->initTrjPublisher();
             theWalkingStack ws(*_model_ptr);
@@ -518,8 +518,8 @@ namespace{
             Eigen::Affine3d r_wrist_init; _model_ptr->getPose("r_wrist","DWYTorso",r_wrist_init);
 
             KDL::Frame r_wrist_init_kdl;
-            tf::transformEigenToKDL(r_wrist_init, r_wrist_init_kdl);
-            tf::transformEigenToKDL(com_init, com_init_kdl);
+            tf2::transformEigenToKDL(r_wrist_init, r_wrist_init_kdl);
+            tf2::transformEigenToKDL(com_init, com_init_kdl);
             this->initManipTrj(com_init_kdl,  r_wrist_init_kdl);
             this->initManipTrjPublisher();
 
@@ -590,9 +590,9 @@ namespace{
         this->_model_ptr->getPose("r_sole", r_foot_init);
 
 
-        tf::transformEigenToKDL(com_init, com_init_kdl);
-        tf::transformEigenToKDL(l_foot_init, l_foot_init_kdl);
-        tf::transformEigenToKDL(r_foot_init, r_foot_init_kdl);
+        tf2::transformEigenToKDL(com_init, com_init_kdl);
+        tf2::transformEigenToKDL(l_foot_init, l_foot_init_kdl);
+        tf2::transformEigenToKDL(r_foot_init, r_foot_init_kdl);
         this->initTrj(com_init_kdl, l_foot_init_kdl, r_foot_init_kdl);
         this->initTrjPublisher();
 

--- a/include/OpenSoT/constraints/velocity/CollisionAvoidance.h
+++ b/include/OpenSoT/constraints/velocity/CollisionAvoidance.h
@@ -26,7 +26,6 @@
 #include <srdfdom/model.h>
 #include <Eigen/Dense>
 
-#include <moveit_msgs/PlanningSceneWorld.h>
 
 namespace OpenSoT { namespace constraints { namespace velocity {
 

--- a/src/tasks/acceleration/Cartesian.cpp
+++ b/src/tasks/acceleration/Cartesian.cpp
@@ -1,6 +1,6 @@
 #include <OpenSoT/tasks/acceleration/Cartesian.h>
 #include <xbot2_interface/logger.h>
-#include <eigen_conversions/eigen_kdl.h>
+#include <tf2_eigen_kdl/tf2_eigen_kdl.hpp>
 
 using XBot::Logger;
 using namespace OpenSoT::tasks::acceleration;
@@ -215,8 +215,8 @@ void Cartesian::setReference(const Eigen::Affine3d& pose_ref,
 void Cartesian::setReference(const KDL::Frame& pose_ref,
                              const KDL::Twist& vel_ref)
 {
-    tf::transformKDLToEigen(pose_ref, _pose_ref);
-    tf::twistKDLToEigen(vel_ref, _vel_ref);
+    tf2::transformKDLToEigen(pose_ref, _pose_ref);
+    tf2::twistKDLToEigen(vel_ref, _vel_ref);
     _acc_ref.setZero();
 
     _vel_ref_cached = _vel_ref;
@@ -239,9 +239,9 @@ void Cartesian::setReference(const KDL::Frame& pose_ref,
                              const KDL::Twist& vel_ref,
                              const KDL::Twist& acc_ref)
 {
-    tf::transformKDLToEigen(pose_ref, _pose_ref);
-    tf::twistKDLToEigen(vel_ref, _vel_ref);
-    tf::twistKDLToEigen(acc_ref, _acc_ref);
+    tf2::transformKDLToEigen(pose_ref, _pose_ref);
+    tf2::twistKDLToEigen(vel_ref, _vel_ref);
+    tf2::twistKDLToEigen(acc_ref, _acc_ref);
 
     _vel_ref_cached = _vel_ref;
     _acc_ref_cached = _acc_ref;
@@ -319,7 +319,7 @@ void Cartesian::getReference(Eigen::Affine3d& ref) const
 
 void Cartesian::getReference(KDL::Frame& ref) const
 {
-    tf::transformEigenToKDL(_pose_ref, ref);
+    tf2::transformEigenToKDL(_pose_ref, ref);
 }
 
 void Cartesian::getReference(Eigen::Affine3d& desiredPose,
@@ -332,8 +332,8 @@ void Cartesian::getReference(Eigen::Affine3d& desiredPose,
 void Cartesian::getReference(KDL::Frame& desiredPose,
                              KDL::Twist& desiredTwist) const
 {
-    tf::transformEigenToKDL(_pose_ref, desiredPose);
-    tf::twistEigenToKDL(_vel_ref, desiredTwist);
+    tf2::transformEigenToKDL(_pose_ref, desiredPose);
+    tf2::twistEigenToKDL(_vel_ref, desiredTwist);
 }
 
 void Cartesian::getReference(Eigen::Affine3d& desiredPose,
@@ -349,9 +349,9 @@ void Cartesian::getReference(KDL::Frame& desiredPose,
                              KDL::Twist& desiredTwist,
                              KDL::Twist& desiredAcceleration) const
 {
-    tf::transformEigenToKDL(_pose_ref, desiredPose);
-    tf::twistEigenToKDL(_vel_ref, desiredTwist);
-    tf::twistEigenToKDL(_acc_ref, desiredAcceleration);
+    tf2::transformEigenToKDL(_pose_ref, desiredPose);
+    tf2::twistEigenToKDL(_vel_ref, desiredTwist);
+    tf2::twistEigenToKDL(_acc_ref, desiredAcceleration);
 }
 
 
@@ -362,7 +362,7 @@ void Cartesian::getActualPose(Eigen::Affine3d& actual) const
 
 void Cartesian::getActualPose(KDL::Frame& actual)
 {
-    tf::transformEigenToKDL(_pose_current, actual);
+    tf2::transformEigenToKDL(_pose_current, actual);
 }
 
 const Eigen::Affine3d& Cartesian::getActualPose() const
@@ -377,7 +377,7 @@ void Cartesian::getActualTwist(Eigen::Vector6d& actual) const
 
 void Cartesian::getActualTwist(KDL::Twist& actual)
 {
-    tf::twistEigenToKDL(_vel_current, actual);
+    tf2::twistEigenToKDL(_vel_current, actual);
 }
 
 const Eigen::Vector6d& Cartesian::getActualTwist() const

--- a/src/utils/cartesian_utils.cpp
+++ b/src/utils/cartesian_utils.cpp
@@ -19,7 +19,7 @@
 
 #include <OpenSoT/utils/cartesian_utils.h>
 #include <memory>
-#include <eigen_conversions/eigen_kdl.h>
+#include <tf2_eigen_kdl/tf2_eigen_kdl.hpp>
 
 #define toDeg(X) (X*180.0/M_PI)
 
@@ -45,14 +45,14 @@ void cartesian_utils::computeCartesianError(const Eigen::Matrix4d &T,
     KDL::Frame x; // ee pose
     x.Identity();
     Eigen::Matrix4d tmp = T;
-    tf::transformEigenToKDL(Eigen::Affine3d(tmp),x);
+    tf2::transformEigenToKDL(Eigen::Affine3d(tmp),x);
     quaternion q;
     x.M.GetQuaternion(q.x, q.y, q.z, q.w);
 
     KDL::Frame xd; // ee desired pose
     xd.Identity();
     tmp = Td;
-    tf::transformEigenToKDL(Eigen::Affine3d(tmp),xd);
+    tf2::transformEigenToKDL(Eigen::Affine3d(tmp),xd);
     quaternion qd;
     xd.M.GetQuaternion(qd.x, qd.y, qd.z, qd.w);
 

--- a/tests/collision_utils.cpp
+++ b/tests/collision_utils.cpp
@@ -590,7 +590,7 @@ std::shared_ptr<fcl::CollisionObjectd> fcl_from_primitive(
 
     // set transform
     fcl::Transform3d w_T_octo;
-    tf::poseMsgToEigen(pose, w_T_octo);
+    tf2::poseMsgToEigen(pose, w_T_octo);
     co->setTransform(w_T_octo);
 
     return co;
@@ -686,7 +686,7 @@ bool ComputeLinksDistance::setWorldCollisions(const moveit_msgs::PlanningSceneWo
 
     // set transform
     fcl::Transform3d w_T_octo;
-    tf::poseMsgToEigen(wc.octomap.origin, w_T_octo);
+    tf2::poseMsgToEigen(wc.octomap.origin, w_T_octo);
     coll_obj->setTransform(w_T_octo);
 
     // save collision object

--- a/tests/constraints/force/TestFrictionCones.cpp
+++ b/tests/constraints/force/TestFrictionCones.cpp
@@ -11,7 +11,7 @@
 #include <ros/master.h>
 #include <sensor_msgs/JointState.h>
 #include <tf/transform_broadcaster.h>
-#include <eigen_conversions/eigen_kdl.h>
+#include <tf2_eigen_kdl/tf2_eigen_kdl.hpp>
 
 #include "../../common.h"
 

--- a/tests/constraints/velocity/TestCollisionAvoidanceEnvironment.cpp
+++ b/tests/constraints/velocity/TestCollisionAvoidanceEnvironment.cpp
@@ -296,7 +296,7 @@ TEST_F(testCollisionAvoidanceConstraint, testEnvironmentCollisionAvoidance){
         cube.color.g = 1.0;
         cube.color.a = 0.5;
 
-        tf::poseEigenToMsg ( w_T_c, cube.pose );
+        tf2::poseEigenToMsg ( w_T_c, cube.pose );
 #endif
 
 

--- a/tests/solvers/TestEigenSVD_StaticWalk_FloatingBase.cpp
+++ b/tests/solvers/TestEigenSVD_StaticWalk_FloatingBase.cpp
@@ -37,10 +37,10 @@ namespace{
 
 KDL::Frame poseEigenToKDL(const Eigen::Affine3d& T)
 {
-    tf::Pose tmp;
-    tf::poseEigenToTF(T, tmp);
+    tf2::Pose tmp;
+    tf2::poseEigenToTF(T, tmp);
     KDL::Frame tmp2;
-    tf::poseTFToKDL(tmp, tmp2);
+    tf2::poseTFToKDL(tmp, tmp2);
     return tmp2;
 }
 
@@ -384,7 +384,7 @@ public:
         if(IS_ROSCORE_RUNNING){
 
             _n.reset(new ros::NodeHandle());
-            world_broadcaster.reset(new tf::TransformBroadcaster());
+            world_broadcaster.reset(new tf2::TransformBroadcaster());
 
         }
     }
@@ -526,10 +526,10 @@ public:
             Eigen::Affine3d world_T_bl;
             _model_ptr->getPose("Waist",world_T_bl);
 
-            tf::Transform anchor_T_world;
-            tf::transformEigenToTF(world_T_bl, anchor_T_world);
+            tf2::Transform anchor_T_world;
+            tf2::transformEigenToTF(world_T_bl, anchor_T_world);
 
-            world_broadcaster->sendTransform(tf::StampedTransform(
+            world_broadcaster->sendTransform(tf2::StampedTransform(
                 anchor_T_world.inverse(), joint_msg.header.stamp,
                 "Waist", "world"));
 
@@ -561,7 +561,7 @@ public:
     std::shared_ptr<trajectory_utils::trajectory_publisher> r_wrist_trj_pub;
 
     ros::Publisher joint_state_pub;
-    std::shared_ptr<tf::TransformBroadcaster> world_broadcaster;
+    std::shared_ptr<tf2::TransformBroadcaster> world_broadcaster;
 
     rviz_visual_tools::RvizVisualToolsPtr visual_tools;
 

--- a/tests/solvers/TestOSQP.cpp
+++ b/tests/solvers/TestOSQP.cpp
@@ -8,7 +8,7 @@
 #include <OpenSoT/tasks/velocity/Cartesian.h>
 #include <OpenSoT/solvers/iHQP.h>
 #include <OpenSoT/constraints/velocity/VelocityLimits.h>
-#include <eigen_conversions/eigen_kdl.h>
+#include <tf2_eigen_kdl/tf2_eigen_kdl.hpp>
 #include "../common.h"
 
 #define GREEN "\033[0;32m"
@@ -506,7 +506,7 @@ TEST_F(testOSQPProblem, testContructor2Problems)
     std::cout<<"INITIAL CONFIG: "<<T_init.matrix()<<std::endl;
     KDL::Frame T_kdl;
     auto Teigen = _model_ptr->getPose("l_wrist", "Waist");
-    tf::transformEigenToKDL(Teigen, T_kdl);
+    tf2::transformEigenToKDL(Teigen, T_kdl);
 
 
     for(unsigned int i = 0; i < 3; ++i)

--- a/tests/solvers/TestQPOases.cpp
+++ b/tests/solvers/TestQPOases.cpp
@@ -14,7 +14,7 @@
 #include <OpenSoT/tasks/velocity/MinimumEffort.h>
 #include <xbot2_interface/xbotinterface2.h>
 #include <OpenSoT/utils/AutoStack.h>
-#include <eigen_conversions/eigen_kdl.h>
+#include <tf2_eigen_kdl/tf2_eigen_kdl.hpp>
 
 #include "../common.h"
 
@@ -950,7 +950,7 @@ TEST_F(testiHQP, testContructor2Problems)
     std::cout<<"INITIAL CONFIG: "<<T_init.matrix()<<std::endl;
     Eigen::Affine3d T = _model_ptr->getPose("l_wrist", "Waist");
     KDL::Frame T_kdl;
-    tf::transformEigenToKDL(T, T_kdl);
+    tf2::transformEigenToKDL(T, T_kdl);
     // std::cout<<"FINAL CONFIG: "<< T_kdl<<std::endl;
     // std::cout<<"DESIRED CONFIG: "<<T_ref_kdl<<std::endl;
 

--- a/tests/solvers/TesteiQuadProg.cpp
+++ b/tests/solvers/TesteiQuadProg.cpp
@@ -7,7 +7,7 @@
 #include <OpenSoT/tasks/velocity/Cartesian.h>
 #include <OpenSoT/solvers/iHQP.h>
 #include <OpenSoT/constraints/velocity/VelocityLimits.h>
-#include <eigen_conversions/eigen_kdl.h>
+#include <tf2_eigen_kdl/tf2_eigen_kdl.hpp>
 #include "../common.h"
 
 
@@ -516,11 +516,11 @@ TEST_F(testeiQuadProgProblem, testContructor2Problems)
     _model_ptr->getPose("l_wrist", "Waist", T);
 
     KDL::Frame T_kdl;
-    tf::transformEigenToKDL(T, T_kdl);
+    tf2::transformEigenToKDL(T, T_kdl);
 
     std::cout<<"FINAL CONFIG: "<<T.matrix()<<std::endl;
     Eigen::Affine3d T_ref;
-    tf::transformKDLToEigen(T_ref_kdl, T_ref);
+    tf2::transformKDLToEigen(T_ref_kdl, T_ref);
     std::cout<<"DESIRED CONFIG: "<<T_ref.matrix()<<std::endl;
 
 

--- a/tests/solvers/TestqpSWIFT.cpp
+++ b/tests/solvers/TestqpSWIFT.cpp
@@ -9,7 +9,7 @@
 #include <OpenSoT/tasks/velocity/Cartesian.h>
 #include <OpenSoT/solvers/iHQP.h>
 #include <OpenSoT/constraints/velocity/VelocityLimits.h>
-#include <eigen_conversions/eigen_kdl.h>
+#include <tf2_eigen_kdl/tf2_eigen_kdl.hpp>
 #include "../common.h"
 
 
@@ -538,7 +538,7 @@ TEST_F(testqpSWIFTProblem, testContructor2Problems)
     T_ref_kdl.p[0] = 0.283; T_ref_kdl.p[1] = 0.156; T_ref_kdl.p[2] = 0.499;
     T_ref_kdl.M = T_ref_kdl.M.Quaternion(0.0, 0.975, 0.0, -0.221);
     Eigen::Affine3d T_ref;
-    tf::transformKDLToEigen(T_ref_kdl, T_ref);
+    tf2::transformKDLToEigen(T_ref_kdl, T_ref);
     cartesian_task->setReference(T_ref);
 
     //Solve SoT

--- a/tests/utils/collision_utils_test.cpp
+++ b/tests/utils/collision_utils_test.cpp
@@ -47,8 +47,8 @@ Eigen::Affine3d fcl2Eigen(const fcl::Transform3<double> &in)
 
 // local version of vectorKDLToEigen since oldest versions are bogous.
 // To use instead of:
-// #include <eigen_conversions/eigen_kdl.h>
-// tf::vectorKDLToEigen
+// #include <tf2_eigen_kdl/tf2_eigen_kdl.hpp>
+// tf2::vectorKDLToEigen
 void vectorKDLToEigen(const KDL::Vector &k, Eigen::Matrix<double, 3, 1> &e)
 {
   for(int i = 0; i < 3; ++i)


### PR DESCRIPTION
With this PR you can compile openSoT with ROS 2 dependencies. For this to work you need to install [matlogger2](https://github.com/ADVRHumanoids/MatLogger2) and xbot2_interface.

Then you can install it with

Install instructions:
```bash
sudo apt install -y libboost-all-dev ros-humble-srdfdom ros-humble-pinocchio ros-humble-tf2-eigen-kdl ros-humble-hpp-fcl ros-humble-geometric-shapes ros-humble-moveit-core ros-humble-pcl-ros

mkdir build
cd build
source /opt/ros/humble/setup.bash
cmake .. -DCMAKE_BUILD_TYPE=Release 
make -j16
cpack -G DEB
sudo dpkg -i *.deb
sudo ldconfig
```