### PR TITLE
Allow setting lambda in raw params setter of admittance task

### DIFF
--- a/src/tasks/velocity/CartesianAdmittance.cpp
+++ b/src/tasks/velocity/CartesianAdmittance.cpp
@@ -248,12 +248,6 @@ bool OpenSoT::tasks::velocity::CartesianAdmittance::setRawParams(const Eigen::Ve
                                                                  const double lambda, 
                                                                  const double dt)
 {
-
-    if(lambda != 0)
-    {
-        throw std::invalid_argument("TBD lambda > 0");
-    }
-
     if((C.array() < 0).any())
     {
         return false;


### PR DESCRIPTION
- updated version of Admittance task depends on velocity and position tracking via lambda parameter, but in setter of raw admittance params, lambda with non-zero value was still blocked due to previous structure