### PR TITLE
Fix RPath of python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 cmake_minimum_required(VERSION 3.10)
 include(ExternalProject)
-project(open_sot VERSION 4.0.0)
+project(open_sot VERSION 4.0.1)
 
 set(CMAKE_CXX_STANDARD 20)
 
@@ -20,6 +20,8 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 
 set(${CMAKE_PROJECT_NAME}_CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE})
+
+set(CMAKE_INSTALL_RPATH $ORIGIN)
 
 add_subdirectory(doc)
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -33,6 +33,8 @@ if(${pybind11_FOUND})
     pybind11_add_module(pyopensot ${OPENSOT_BINDINGS_SOURCES})
 
     target_link_libraries(pyopensot PUBLIC OpenSoT)
+    set_target_properties(pyopensot PROPERTIES INSTALL_RPATH "$ORIGIN/../..")
+
 
     # Check if we install into system pathes ( something /usr/* )
     # In Debian/Ubuntu site-packages are named dist-packages there
@@ -59,6 +61,7 @@ if(${pybind11_FOUND})
         pybind11_add_module(pyopensot_collision ${OPENSOT_BINDINGS_COLLISION_SOURCES})
 
         target_link_libraries(pyopensot_collision PUBLIC OpenSoT)
+        set_target_properties(pyopensot_collision PROPERTIES INSTALL_RPATH "$ORIGIN/../..")
 
         install(TARGETS pyopensot_collision
             COMPONENT python


### PR DESCRIPTION
Set Rpathes.

The local ones should be rpathed to the current directory as they obviously are dependent of each other.
The python ones have a path two the grandparentdirectory as there are the origin libraries the bindings are binding to.