### PR TITLE
Replace a print with proper logger statement

### DIFF
--- a/src/solvers/BackEndFactory.cpp
+++ b/src/solvers/BackEndFactory.cpp
@@ -22,10 +22,10 @@ OpenSoT::solvers::BackEnd::Ptr OpenSoT::solvers::BackEndFactory(const solver_bac
                                                                 OpenSoT::HessianType hessian_type,
                                                                 const double eps_regularisation)
 {
-    std::cout << "BackEndFactory will load solver " <<
+    XBot::Logger::info() << "BackEndFactory will load solver " <<
         number_of_variables << " variables, " <<
         number_of_constraints << " constraints,  " <<
-        eps_regularisation << " regularization \n";
+        eps_regularisation << " regularization " << XBot::Logger::endl();
 
     if (be_solver == solver_back_ends::qpOASES) {
         return CreateBackend("QPOases",


### PR DESCRIPTION
This is needed to keep OpenSoT completely silent. Doesn't make sense to configure a logger if there are outputs independent of the logger...